### PR TITLE
(fix) Shape and bbox error

### DIFF
--- a/scripts/pose_cls_e2e_inference/plot_e2e_inference.py
+++ b/scripts/pose_cls_e2e_inference/plot_e2e_inference.py
@@ -69,10 +69,19 @@ def main():
                     for j in range(num_joints):
                         image_frame = cv2.circle(image_frame, joints[j], 2, (255, 255, 255), 2)
 
+
+
+                    #Fix bbox, using minmax joints point
+                    x_list,y_list = zip(*joints)
+                    x_min = min(x_list)
+                    x_max = max(x_list)
+                    y_min = min(y_list)
+                    y_max = max(y_list)
+                    bbox = [x_min,y_min,x_max,y_max]
+                    
                     # Plot bounding box
-                    bbox = person["bbox"]
                     bbox_top_left = [int(bbox[0]), int(bbox[1])]
-                    bbox_bottom_right = [int(bbox[0] + bbox[2] - 1), int(bbox[1] + bbox[3] - 1)]
+                    bbox_bottom_right = [int(bbox[2]), int(bbox[3])]
                     if bbox_top_left[0] < 0:
                         bbox_top_left[0] = 0
                     if bbox_top_left[1] < 0:

--- a/tao_triton/python/utils/pose_cls_dataset_convert.py
+++ b/tao_triton/python/utils/pose_cls_dataset_convert.py
@@ -139,7 +139,9 @@ def pose_cls_dataset_convert(pose_data_file, dataset_convert_config):
             frame_start += step
 
         # Accumulate data arrays of all objects
-        data_arrays.append(data_array)
+        if data_array is not None:
+            data_arrays.append(data_array)
+            print(data_array.shape)
 
     # Update pose data for returning (removing pose metadata)
     for b in range(len(pose_data)):
@@ -151,5 +153,4 @@ def pose_cls_dataset_convert(pose_data_file, dataset_convert_config):
                 pose_data[b]["batches"][f]["objects"][p]["segment_id"] = \
                     segment_assignments.get((object_id, frame_num), -1)
                 pose_data[b]["batches"][f]["objects"][p]["action"] = ""
-
     return np.concatenate(data_arrays, axis=0), pose_data


### PR DESCRIPTION
Add a small code to fix an error relate to pose_cls_dataset_convert.py when some times this condition `while len(pose_sequences[object_id]) - frame_start >= sequence_length_min:` was not  met and the code add an extra None array to `data_array`. This generate a problem in the E2E inference in Pose Classification.

```
if data_array is not None:
    data_arrays.append(data_array)
```

The other small code I added was in `plot_e2e_inference.py`. I just add this to draw the bbox without the presence of the variable "bbox" in the files:

```
#Fix bbox, using minmax joints point
x_list,y_list = zip(*joints)
x_min = min(x_list)
x_max = max(x_list)
y_min = min(y_list)
y_max = max(y_list)
bbox = [x_min,y_min,x_max,y_max]
```